### PR TITLE
Fixed NotADatabaseException #6, tested on Ubuntu 2018.04

### DIFF
--- a/wimgs.rb
+++ b/wimgs.rb
@@ -154,7 +154,7 @@ def get_image(mw, cfg, img)
 end
 
 # main
-cfg = { :list => nil, :imgdir => './images', :resume => true, :status => false, :wiki => nil, :width => nil, :category => nil, :dbname => "wimgs" }
+cfg = { :list => nil, :imgdir => './images', :resume => true, :status => false, :wiki => nil, :width => nil, :category => nil, :dbname => "wimgs.db" }
 
 opts = GetoptLong.new(
   [ '--help', '-h', GetoptLong::NO_ARGUMENT ],

--- a/wimgs.rb
+++ b/wimgs.rb
@@ -154,7 +154,7 @@ def get_image(mw, cfg, img)
 end
 
 # main
-cfg = { :list => nil, :imgdir => './images', :resume => true, :status => false, :wiki => nil, :width => nil, :category => nil, :dbname => "wimgs.rb" }
+cfg = { :list => nil, :imgdir => './images', :resume => true, :status => false, :wiki => nil, :width => nil, :category => nil, :dbname => "wimgs" }
 
 opts = GetoptLong.new(
   [ '--help', '-h', GetoptLong::NO_ARGUMENT ],


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/48974135/sqlite-error-file-is-not-a-database